### PR TITLE
routes.rbにtasksコントローラーにアクセスできるよう記述

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   resources :tasks
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root 'tasks#index'
+
 end


### PR DESCRIPTION
# routes.rbにtasksコントローラーにアクセスできるよう記述
 - tasksコントローラーのindexメソッドにアクセス可能になる