### PR TITLE
post送信時、/callbackメソッドを見るとline_botコントローラーのcallbackメソッドに飛ぶように設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'line_bot/callback'
+  post '/callback' => 'line_bot#callback'
   resources :tasks
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'tasks#index'


### PR DESCRIPTION
# post送信時、/callbackメソッドを見るとline_botコントローラーのcallbackメソッドに飛ぶように設定